### PR TITLE
Add Linea Mini Touchscreen Controller

### DIFF
--- a/public/images/mods/linea-mini-controller-installed.jpg
+++ b/public/images/mods/linea-mini-controller-installed.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2784cd52f993f07e4742cf2aa8b01bdc50e7f148cbc36376ce0793b07e0d873c
+size 157378

--- a/src/content/mods/linea-mini-controller.json
+++ b/src/content/mods/linea-mini-controller.json
@@ -1,0 +1,13 @@
+{
+  "slug": "linea-mini-controller",
+  "title": "Linea Mini Touchscreen Controller",
+  "creator": "Sc00bs110",
+  "creatorUrl": "https://github.com/Sc00bs110",
+  "type": [
+    "shot-timer",
+    "brew-by-weight"
+  ],
+  "url": "https://github.com/Sc00bs110/linea-mini-controller",
+  "content": "![ESP32 touchscreen controller installed on a Linea Mini](/images/mods/linea-mini-controller-installed.jpg)\n\nAn open-source ESP32-S3 touchscreen controller, built for the **Linea Mini** (the Micra's bigger sibling — both machines use a GICAR control board, so the approach may carry over). It plugs into the machine's CN11 diagnostic connector and speaks the same serial protocol as the factory panel — no modification to the machine's electronics.\n\nFeatures: live boiler temperature and shot timer, brew-by-weight via BLE scale (Felicita Arc / Bookoo Themis), flush-vs-shot detection, cleaning-cycle reminders, standby scheduling, Home Assistant integration over MQTT, and self-updating firmware from GitHub releases. Firmware, wiring guide, and 3D-printable housing are all in the repo.",
+  "filename": "Linea Mini Touchscreen Controller.md"
+}


### PR DESCRIPTION
Adds my open-source ESP32-S3 touchscreen controller. It's built for the Linea Mini rather than the Micra (noted clearly in the description), but both machines use a GICAR control board and the CN11 approach may be portable — happy to reword or split it out if you'd rather keep the list Micra-only. Entry JSON follows the existing format; photo included in `public/images/mods/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)